### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os: linux
 dist: trusty
+group: edge
 language: c
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ env:
   global:
     - MAKEFLAGS="-j3 --output-sync"
 before_install:
-  - wget http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz || wget http://qmk.fm/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
+  - wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | tar xj
 install:
-  - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
-  - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
+  - export PATH="$PATH:$TRAVIS_BUILD_DIR/gcc-arm-none-eabi-6-2017-q2-update/bin"
 script:
   - rake ci
 addons:
   apt:
     packages:
-      - dfu-programmer
-      - gcc-arm-none-eabi
+      - avr-libc
       - binutils-arm-none-eabi
-      - libnewlib-arm-none-eabi
+      - binutils-avr
+      - dfu-programmer
       - diffutils
+      - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
   apt:
     packages:
       - dfu-programmer
-      - dfu-util
       - gcc-arm-none-eabi
       - binutils-arm-none-eabi
       - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ addons:
   apt:
     packages:
       - avr-libc
+      - avrdude
       - binutils-arm-none-eabi
       - binutils-avr
+      - build-essential
       - dfu-programmer
       - diffutils
+      - gcc
       - gcc-avr
       - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ addons:
       - binutils-avr
       - dfu-programmer
       - diffutils
+      - gcc-avr
       - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 os: linux
-dist: trusty
-group: edge
 language: c
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: c
 env:
   global:
     - MAKEFLAGS="-j3 --output-sync"
-before_install:
-  - wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | tar xj
-install:
-  - export PATH="$PATH:$TRAVIS_BUILD_DIR/gcc-arm-none-eabi-6-2017-q2-update/bin"
 script:
   - rake ci
 addons:
@@ -18,4 +14,5 @@ addons:
       - dfu-programmer
       - dfu-util
       - gcc-avr
+      - gcc-arm-none-eabi
       - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,10 @@ addons:
   apt:
     packages:
       - avr-libc
-      - avrdude
       - binutils-arm-none-eabi
       - binutils-avr
-      - build-essential
       - dfu-programmer
       - dfu-util
-      - diffutils
       - gcc
       - gcc-avr
       - libnewlib-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - binutils-avr
       - build-essential
       - dfu-programmer
+      - dfu-util
       - diffutils
       - gcc
       - gcc-avr

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,5 @@ addons:
       - binutils-avr
       - dfu-programmer
       - dfu-util
-      - gcc
       - gcc-avr
       - libnewlib-arm-none-eabi


### PR DESCRIPTION
Travis build broke after upgrading QMK firmware, although everything still builds fine locally. This attempts to bring the build script up to date with upstream (but not using Docker).